### PR TITLE
chore(tests): bump sample project in fixtures to dbt 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ package, but it doesn't mean that other dbt and Tableau versions will not work.
 
 | dbt-exposures-crawler | dbt version |        Tableau version         | SQL dialect |
 |:---------------------:|:-----------:|:------------------------------:|:-----------:|
-|        v0.1.4         |  1.1 - 1.4  | Tableau Server 2022.1 - 2023.1 |  Snowflake  |
+|     0.1.4 - 0.1.5     |  1.1 - 1.4  | Tableau Server 2022.1 - 2023.1 |  Snowflake  |
 
 ## Installation
 
@@ -220,24 +220,45 @@ Finally, the `utils` module has functions for logging and string parsing.
 ### Testing
 
 For the integration tests, we use a sample `manifest.json` as a fixture. It was manually generated from
-the [jaffle_shop](https://github.com/fishtown-analytics/jaffle_shop), an official dbt sample project.
+the [jaffle_shop](https://github.com/fishtown-analytics/jaffle_shop), an official dbt sample project. The following
+steps can be used to recreate it or to generate a new manifest on a more recent dbt version.
+
+First, the dbt sample project should be cloned and dbt needs to be installed:
 
 ```shell
 $ git clone https://github.com/fishtown-analytics/jaffle_shop
 $ cd jaffle_shop
 $ pipenv shell
-$ pip install dbt==0.19.1
+$ pip install dbt-snowflake==1.4.4
 ```
 
-After adding an entry on my dbt profile and then setting the default database on the project to `sample_dbt` on
-the `dbt_project.yaml`:
+Then, a new `profiles.yml` should be created in the same folder with the following configuration:
+
+```yaml
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      database: sample_db
+      account: ...
+      user: ...
+      private_key_path: ...
+      private_key_passphrase: ...
+      warehouse: ...
+      role: ...
+      schema: ...
+```
+
+Afterward, the project can be compiled by running:
 
 ```shell
-$ dbt compile --target prod
+$ dbt compile --target dev
 ```
 
-The generated `manifest.json` is then prettified and copied to the `tests/_fixtures` folder. I've also manually removed
-the `macros` entries from the file just to make it easier to navigate through it in case of troubleshooting.
+The generated `manifest.json` should then be prettified and copied to the `tests/_fixtures` folder in this repository.
+You can also manually remove the `macros` entries from the file since they are not needed and they make the file
+much larger and harder to be manually inspected
 
 ```shell
 $ cat target/manifest.json | jq > $PROJECT_ROOT/tests/_fixtures/manifest.json

--- a/tests/_fixtures/manifest.json
+++ b/tests/_fixtures/manifest.json
@@ -1,2613 +1,2652 @@
 {
-    "metadata": {
-        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-        "dbt_version": "0.19.1",
-        "generated_at": "2021-06-12T12:00:33.957001Z",
-        "invocation_id": "a7a1694f-ce15-459b-a398-f70088d6ef00",
-        "env": {},
-        "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
-        "user_id": "9668a411-28cf-4433-9291-d803dda7cfce",
-        "send_anonymous_usage_stats": true,
-        "adapter_type": "snowflake"
-    },
-    "nodes": {
-        "model.jaffle_shop.customers": {
-            "raw_sql": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
-            "compiled": true,
-            "resource_type": "model",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.jaffle_shop.stg_customers",
-                    "model.jaffle_shop.stg_orders",
-                    "model.jaffle_shop.stg_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "customers"
-            ],
-            "unique_id": "model.jaffle_shop.customers",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "customers.sql",
-            "original_file_path": "models/customers.sql",
-            "name": "customers",
-            "alias": "customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "7f193a2c3af2faa53e0bb7b75d2663f39db8c6b3913e9cafd245dc62f98a8d09"
-            },
-            "tags": [],
-            "refs": [
-                [
-                    "stg_customers"
-                ],
-                [
-                    "stg_orders"
-                ],
-                [
-                    "stg_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-            "columns": {
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "This is a unique identifier for a customer",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "first_name": {
-                    "name": "first_name",
-                    "description": "Customer's first name. PII.",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "last_name": {
-                    "name": "last_name",
-                    "description": "Customer's last name. PII.",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "first_order": {
-                    "name": "first_order",
-                    "description": "Date (UTC) of a customer's first order",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "most_recent_order": {
-                    "name": "most_recent_order",
-                    "description": "Date (UTC) of a customer's most recent order",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "number_of_orders": {
-                    "name": "number_of_orders",
-                    "description": "Count of the number of orders a customer has placed",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "total_order_amount": {
-                    "name": "total_order_amount",
-                    "description": "Total value (AUD) of a customer's orders",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": "models/schema.yml",
-            "build_path": "target/compiled/jaffle_shop/models/customers.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table"
-            },
-            "compiled_sql": "with customers as (\n\n    select * from sample_db.public.stg_customers\n\n),\n\norders as (\n\n    select * from sample_db.public.stg_orders\n\n),\n\npayments as (\n\n    select * from sample_db.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "sample_db.public.customers",
-            "materialized_name": "sample_db.public.customers"
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v8.json",
+    "dbt_version": "1.4.8",
+    "generated_at": "2023-09-26T16:22:56.390684Z",
+    "invocation_id": "13fefa72-6e1e-4460-b686-61f851c52f3d",
+    "env": {},
+    "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+    "user_id": "6cd10d13-b8f8-4434-9ee9-6d0b64be9530",
+    "send_anonymous_usage_stats": true,
+    "adapter_type": "snowflake"
+  },
+  "nodes": {
+    "model.jaffle_shop.customers": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "customers",
+      "resource_type": "model",
+      "package_name": "jaffle_shop",
+      "path": "customers.sql",
+      "original_file_path": "models/customers.sql",
+      "unique_id": "model.jaffle_shop.customers",
+      "fqn": [
+        "jaffle_shop",
+        "customers"
+      ],
+      "alias": "customers",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "455b90a31f418ae776213ad9932c7cb72d19a5269a8c722bd9f4e44957313ce8"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "table",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
         },
-        "model.jaffle_shop.orders": {
-            "raw_sql": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
-            "compiled": true,
-            "resource_type": "model",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.jaffle_shop.stg_orders",
-                    "model.jaffle_shop.stg_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "orders"
-            ],
-            "unique_id": "model.jaffle_shop.orders",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "orders.sql",
-            "original_file_path": "models/orders.sql",
-            "name": "orders",
-            "alias": "orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "ec3e8884f18110dd6d9b1ababdd85a6c04bf665ee0f57cade273e442f90e9994"
-            },
-            "tags": [],
-            "refs": [
-                [
-                    "stg_orders"
-                ],
-                [
-                    "stg_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "This table has basic information about orders, as well as some derived facts based on payments",
-            "columns": {
-                "order_id": {
-                    "name": "order_id",
-                    "description": "This is a unique identifier for an order",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "Foreign key to the customers table",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "order_date": {
-                    "name": "order_date",
-                    "description": "Date (UTC) that the order was placed",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "status": {
-                    "name": "status",
-                    "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "amount": {
-                    "name": "amount",
-                    "description": "Total amount (AUD) of the order",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "credit_card_amount": {
-                    "name": "credit_card_amount",
-                    "description": "Amount of the order (AUD) paid for by credit card",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "coupon_amount": {
-                    "name": "coupon_amount",
-                    "description": "Amount of the order (AUD) paid for by coupon",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "bank_transfer_amount": {
-                    "name": "bank_transfer_amount",
-                    "description": "Amount of the order (AUD) paid for by bank transfer",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "gift_card_amount": {
-                    "name": "gift_card_amount",
-                    "description": "Amount of the order (AUD) paid for by gift card",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": "models/schema.yml",
-            "build_path": "target/compiled/jaffle_shop/models/orders.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table"
-            },
-            "compiled_sql": "\n\nwith orders as (\n\n    select * from sample_db.public.stg_orders\n\n),\n\npayments as (\n\n    select * from sample_db.public.stg_payments\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "sample_db.public.orders",
-            "materialized_name": "sample_db.public.orders"
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "This is a unique identifier for a customer",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "model.jaffle_shop.stg_customers": {
-            "raw_sql": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-            "compiled": true,
-            "resource_type": "model",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.jaffle_shop.raw_customers"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "view",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "staging",
-                "stg_customers"
-            ],
-            "unique_id": "model.jaffle_shop.stg_customers",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "staging/stg_customers.sql",
-            "original_file_path": "models/staging/stg_customers.sql",
-            "name": "stg_customers",
-            "alias": "stg_customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "6f18a29204dad1de6dbb0c288144c4990742e0a1e065c3b2a67b5f98334c22ba"
-            },
-            "tags": [],
-            "refs": [
-                [
-                    "raw_customers"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": "models/staging/schema.yml",
-            "build_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "view"
-            },
-            "compiled_sql": "with source as (\n    select * from model.public.raw_customers\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "sample_db.public.stg_customers",
-            "materialized_name": "sample_db.public.stg_customers"
+        "first_name": {
+          "name": "first_name",
+          "description": "Customer's first name. PII.",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "model.jaffle_shop.stg_payments": {
-            "raw_sql": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-            "compiled": true,
-            "resource_type": "model",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.jaffle_shop.raw_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "view",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "staging",
-                "stg_payments"
-            ],
-            "unique_id": "model.jaffle_shop.stg_payments",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "staging/stg_payments.sql",
-            "original_file_path": "models/staging/stg_payments.sql",
-            "name": "stg_payments",
-            "alias": "stg_payments",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "113502ed19f04efb2af0629ff139f57f7463347b6d5218f3b80a8d128cc96852"
-            },
-            "tags": [],
-            "refs": [
-                [
-                    "raw_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {
-                "payment_id": {
-                    "name": "payment_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "payment_method": {
-                    "name": "payment_method",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": "models/staging/schema.yml",
-            "build_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "view"
-            },
-            "compiled_sql": "with source as (\n    select * from model.public.raw_payments\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "sample_db.public.stg_payments",
-            "materialized_name": "sample_db.public.stg_payments"
+        "last_name": {
+          "name": "last_name",
+          "description": "Customer's last name. PII.",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "model.jaffle_shop.stg_orders": {
-            "raw_sql": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-            "compiled": true,
-            "resource_type": "model",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.jaffle_shop.raw_orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "view",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "staging",
-                "stg_orders"
-            ],
-            "unique_id": "model.jaffle_shop.stg_orders",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "staging/stg_orders.sql",
-            "original_file_path": "models/staging/stg_orders.sql",
-            "name": "stg_orders",
-            "alias": "stg_orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "afffa9cbc57e5fd2cf5898ebf571d444a62c9d6d7929d8133d30567fb9a2ce97"
-            },
-            "tags": [],
-            "refs": [
-                [
-                    "raw_orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {
-                "order_id": {
-                    "name": "order_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                },
-                "status": {
-                    "name": "status",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": "models/staging/schema.yml",
-            "build_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "view"
-            },
-            "compiled_sql": "with source as (\n    select * from model.public.raw_orders\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "sample_db.public.stg_orders",
-            "materialized_name": "sample_db.public.stg_orders"
+        "first_order": {
+          "name": "first_order",
+          "description": "Date (UTC) of a customer's first order",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "seed.jaffle_shop.raw_customers": {
-            "raw_sql": "",
-            "compiled": true,
-            "resource_type": "seed",
-            "depends_on": {
-                "macros": [],
-                "nodes": []
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "seed",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "full_refresh": null,
-                "quote_columns": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "model",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "raw_customers"
-            ],
-            "unique_id": "seed.jaffle_shop.raw_customers",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "raw_customers.csv",
-            "original_file_path": "data/raw_customers.csv",
-            "name": "raw_customers",
-            "alias": "raw_customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "24579b4b26098d43265376f3c50be8b10faf8e8fd95f5508074f10f76a12671d"
-            },
-            "tags": [],
-            "refs": [],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "compiled_sql": "",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "model.public.raw_customers",
-            "materialized_name": "model.public.raw_customers"
+        "most_recent_order": {
+          "name": "most_recent_order",
+          "description": "Date (UTC) of a customer's most recent order",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "seed.jaffle_shop.raw_orders": {
-            "raw_sql": "",
-            "compiled": true,
-            "resource_type": "seed",
-            "depends_on": {
-                "macros": [],
-                "nodes": []
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "seed",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "full_refresh": null,
-                "quote_columns": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "model",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "raw_orders"
-            ],
-            "unique_id": "seed.jaffle_shop.raw_orders",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "raw_orders.csv",
-            "original_file_path": "data/raw_orders.csv",
-            "name": "raw_orders",
-            "alias": "raw_orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "ee6c68d1639ec2b23a4495ec12475e09b8ed4b61e23ab0411ea7ec76648356f7"
-            },
-            "tags": [],
-            "refs": [],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "compiled_sql": "",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "model.public.raw_orders",
-            "materialized_name": "model.public.raw_orders"
+        "number_of_orders": {
+          "name": "number_of_orders",
+          "description": "Count of the number of orders a customer has placed",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         },
-        "seed.jaffle_shop.raw_payments": {
-            "raw_sql": "",
-            "compiled": true,
-            "resource_type": "seed",
-            "depends_on": {
-                "macros": [],
-                "nodes": []
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "seed",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "full_refresh": null,
-                "quote_columns": null,
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "model",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "raw_payments"
-            ],
-            "unique_id": "seed.jaffle_shop.raw_payments",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "raw_payments.csv",
-            "original_file_path": "data/raw_payments.csv",
-            "name": "raw_payments",
-            "alias": "raw_payments",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "03fd407f3135f84456431a923f22fc185a2154079e210c20b690e3ab11687d11"
-            },
-            "tags": [],
-            "refs": [],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "compiled_sql": "",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": "model.public.raw_payments",
-            "materialized_name": "model.public.raw_payments"
-        },
-        "test.jaffle_shop.unique_customers_customer_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ ref('customers') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.customers"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "unique_customers_customer_id"
-            ],
-            "unique_id": "test.jaffle_shop.unique_customers_customer_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/unique_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "unique_customers_customer_id",
-            "alias": "unique_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "customers"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/unique_customers_customer_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        customer_id\n\n    from sample_db.public.customers\n    where customer_id is not null\n    group by customer_id\n    having count(*) > 1\n\n) validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.unique_customers_customer_id"
-        },
-        "test.jaffle_shop.not_null_customers_customer_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ ref('customers') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.customers"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_customers_customer_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_customers_customer_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_customers_customer_id",
-            "alias": "not_null_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "customers"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_customers_customer_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.customers\nwhere customer_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.not_null_customers_customer_id"
-        },
-        "test.jaffle_shop.unique_orders_order_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "unique_orders_order_id"
-            ],
-            "unique_id": "test.jaffle_shop.unique_orders_order_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/unique_orders_order_id.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "unique_orders_order_id",
-            "alias": "unique_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/unique_orders_order_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        order_id\n\n    from sample_db.public.orders\n    where order_id is not null\n    group by order_id\n    having count(*) > 1\n\n) validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "order_id",
-            "materialized_name": "sample_db.public.unique_orders_order_id"
-        },
-        "test.jaffle_shop.not_null_orders_order_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_order_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_order_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_order_id.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_order_id",
-            "alias": "not_null_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_order_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere order_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "order_id",
-            "materialized_name": "sample_db.public.not_null_orders_order_id"
-        },
-        "test.jaffle_shop.not_null_orders_customer_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_customer_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_customer_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_customer_id",
-            "alias": "not_null_orders_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_customer_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere customer_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.not_null_orders_customer_id"
-        },
-        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_relationships(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "relationships",
-                "kwargs": {
-                    "to": "ref('customers')",
-                    "field": "customer_id",
-                    "column_name": "customer_id",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_relationships"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.customers",
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "relationships_orders_customer_id__customer_id__ref_customers_"
-            ],
-            "unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/relationships_orders_60f78bf0ddd08829598a2076a90fd183.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "relationships_orders_customer_id__customer_id__ref_customers_",
-            "alias": "relationships_orders_customer_id__customer_id__ref_customers_",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "customers"
-                ],
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/relationships_orders_60f78bf0ddd08829598a2076a90fd183.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\n\nselect count(*) as validation_errors\nfrom (\n    select customer_id as id from sample_db.public.orders\n) as child\nleft join (\n    select customer_id as id from sample_db.public.customers\n) as parent on parent.id = child.id\nwhere child.id is not null\n  and parent.id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.relationships_orders_customer_id__customer_id__ref_customers_"
-        },
-        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_accepted_values(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "placed",
-                        "shipped",
-                        "completed",
-                        "return_pending",
-                        "returned"
-                    ],
-                    "column_name": "status",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
-            ],
-            "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/accepted_values_orders_758238c28b8980ea7fe9d60a8d851ea8.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-            "alias": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/accepted_values_orders_758238c28b8980ea7fe9d60a8d851ea8.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\n\nwith all_values as (\n\n    select distinct\n        status as value_field\n\n    from sample_db.public.orders\n\n),\n\nvalidation_errors as (\n\n    select\n        value_field\n\n    from all_values\n    where value_field not in (\n        'placed','shipped','completed','return_pending','returned'\n    )\n)\n\nselect count(*) as validation_errors\nfrom validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "status",
-            "materialized_name": "sample_db.public.accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
-        },
-        "test.jaffle_shop.not_null_orders_amount": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "amount",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_amount"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_amount",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_amount",
-            "alias": "not_null_orders_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_amount.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere amount is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "amount",
-            "materialized_name": "sample_db.public.not_null_orders_amount"
-        },
-        "test.jaffle_shop.not_null_orders_credit_card_amount": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "credit_card_amount",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_credit_card_amount"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_credit_card_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_credit_card_amount",
-            "alias": "not_null_orders_credit_card_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_credit_card_amount.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere credit_card_amount is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "credit_card_amount",
-            "materialized_name": "sample_db.public.not_null_orders_credit_card_amount"
-        },
-        "test.jaffle_shop.not_null_orders_coupon_amount": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "coupon_amount",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_coupon_amount"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_coupon_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_coupon_amount",
-            "alias": "not_null_orders_coupon_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_coupon_amount.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere coupon_amount is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "coupon_amount",
-            "materialized_name": "sample_db.public.not_null_orders_coupon_amount"
-        },
-        "test.jaffle_shop.not_null_orders_bank_transfer_amount": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "bank_transfer_amount",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_bank_transfer_amount"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_bank_transfer_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_bank_transfer_amount",
-            "alias": "not_null_orders_bank_transfer_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_bank_transfer_amount.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere bank_transfer_amount is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "bank_transfer_amount",
-            "materialized_name": "sample_db.public.not_null_orders_bank_transfer_amount"
-        },
-        "test.jaffle_shop.not_null_orders_gift_card_amount": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "gift_card_amount",
-                    "model": "{{ ref('orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_orders_gift_card_amount"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_orders_gift_card_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "name": "not_null_orders_gift_card_amount",
-            "alias": "not_null_orders_gift_card_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/schema.yml/schema_test/not_null_orders_gift_card_amount.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.orders\nwhere gift_card_amount is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "gift_card_amount",
-            "materialized_name": "sample_db.public.not_null_orders_gift_card_amount"
-        },
-        "test.jaffle_shop.unique_stg_customers_customer_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ ref('stg_customers') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_customers"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "unique_stg_customers_customer_id"
-            ],
-            "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/unique_stg_customers_customer_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "unique_stg_customers_customer_id",
-            "alias": "unique_stg_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_customers"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/unique_stg_customers_customer_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        customer_id\n\n    from sample_db.public.stg_customers\n    where customer_id is not null\n    group by customer_id\n    having count(*) > 1\n\n) validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.unique_stg_customers_customer_id"
-        },
-        "test.jaffle_shop.not_null_stg_customers_customer_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ ref('stg_customers') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_customers"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_stg_customers_customer_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_stg_customers_customer_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "not_null_stg_customers_customer_id",
-            "alias": "not_null_stg_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_customers"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/not_null_stg_customers_customer_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.stg_customers\nwhere customer_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "customer_id",
-            "materialized_name": "sample_db.public.not_null_stg_customers_customer_id"
-        },
-        "test.jaffle_shop.unique_stg_orders_order_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ ref('stg_orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "unique_stg_orders_order_id"
-            ],
-            "unique_id": "test.jaffle_shop.unique_stg_orders_order_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/unique_stg_orders_order_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "unique_stg_orders_order_id",
-            "alias": "unique_stg_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/unique_stg_orders_order_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        order_id\n\n    from sample_db.public.stg_orders\n    where order_id is not null\n    group by order_id\n    having count(*) > 1\n\n) validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "order_id",
-            "materialized_name": "sample_db.public.unique_stg_orders_order_id"
-        },
-        "test.jaffle_shop.not_null_stg_orders_order_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ ref('stg_orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_stg_orders_order_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_stg_orders_order_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "not_null_stg_orders_order_id",
-            "alias": "not_null_stg_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/not_null_stg_orders_order_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.stg_orders\nwhere order_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "order_id",
-            "materialized_name": "sample_db.public.not_null_stg_orders_order_id"
-        },
-        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_accepted_values(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "placed",
-                        "shipped",
-                        "completed",
-                        "return_pending",
-                        "returned"
-                    ],
-                    "column_name": "status",
-                    "model": "{{ ref('stg_orders') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_orders"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
-            ],
-            "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/accepted_values_stg_orders_758238c28b8980ea7fe9d60a8d851ea8.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-            "alias": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_orders"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/accepted_values_stg_orders_758238c28b8980ea7fe9d60a8d851ea8.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\n\nwith all_values as (\n\n    select distinct\n        status as value_field\n\n    from sample_db.public.stg_orders\n\n),\n\nvalidation_errors as (\n\n    select\n        value_field\n\n    from all_values\n    where value_field not in (\n        'placed','shipped','completed','return_pending','returned'\n    )\n)\n\nselect count(*) as validation_errors\nfrom validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "status",
-            "materialized_name": "sample_db.public.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
-        },
-        "test.jaffle_shop.unique_stg_payments_payment_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ ref('stg_payments') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "unique_stg_payments_payment_id"
-            ],
-            "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/unique_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "unique_stg_payments_payment_id",
-            "alias": "unique_stg_payments_payment_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/unique_stg_payments_payment_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        payment_id\n\n    from sample_db.public.stg_payments\n    where payment_id is not null\n    group by payment_id\n    having count(*) > 1\n\n) validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "payment_id",
-            "materialized_name": "sample_db.public.unique_stg_payments_payment_id"
-        },
-        "test.jaffle_shop.not_null_stg_payments_payment_id": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ ref('stg_payments') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "not_null_stg_payments_payment_id"
-            ],
-            "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/not_null_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "not_null_stg_payments_payment_id",
-            "alias": "not_null_stg_payments_payment_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/not_null_stg_payments_payment_id.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\nselect count(*) as validation_errors\nfrom sample_db.public.stg_payments\nwhere payment_id is null\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "payment_id",
-            "materialized_name": "sample_db.public.not_null_stg_payments_payment_id"
-        },
-        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card": {
-            "raw_sql": "{{ config(severity='ERROR') }}{{ test_accepted_values(**_dbt_schema_test_kwargs) }}",
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "credit_card",
-                        "coupon",
-                        "bank_transfer",
-                        "gift_card"
-                    ],
-                    "column_name": "payment_method",
-                    "model": "{{ ref('stg_payments') }}"
-                },
-                "namespace": null
-            },
-            "compiled": true,
-            "resource_type": "test",
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values"
-                ],
-                "nodes": [
-                    "model.jaffle_shop.stg_payments"
-                ]
-            },
-            "config": {
-                "enabled": true,
-                "materialized": "table",
-                "persist_docs": {},
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "alias": null,
-                "schema": null,
-                "database": "sample_db",
-                "tags": [],
-                "full_refresh": null,
-                "severity": "ERROR",
-                "post-hook": [],
-                "pre-hook": []
-            },
-            "database": "sample_db",
-            "schema": "public",
-            "fqn": [
-                "jaffle_shop",
-                "schema_test",
-                "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
-            ],
-            "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "schema_test/accepted_values_stg_payments_944011baab727320a6b119d4d81589ae.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-            "alias": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "tags": [
-                "schema"
-            ],
-            "refs": [
-                [
-                    "stg_payments"
-                ]
-            ],
-            "sources": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "docs": {
-                "show": true
-            },
-            "patch_path": null,
-            "build_path": "target/compiled/jaffle_shop/models/staging/schema.yml/schema_test/accepted_values_stg_payments_944011baab727320a6b119d4d81589ae.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "database": "sample_db",
-                "materialized": "table",
-                "severity": "ERROR"
-            },
-            "compiled_sql": "\n    \n    \n\n\n\n\nwith all_values as (\n\n    select distinct\n        payment_method as value_field\n\n    from sample_db.public.stg_payments\n\n),\n\nvalidation_errors as (\n\n    select\n        value_field\n\n    from all_values\n    where value_field not in (\n        'credit_card','coupon','bank_transfer','gift_card'\n    )\n)\n\nselect count(*) as validation_errors\nfrom validation_errors\n\n\n",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "relation_name": null,
-            "column_name": "payment_method",
-            "materialized_name": "sample_db.public.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+        "total_order_amount": {
+          "name": "total_order_amount",
+          "description": "Total value (AUD) of a customer's orders",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
         }
-    },
-    "sources": {},
-    "docs": {
-        "jaffle_shop.__overview__": {
-            "unique_id": "jaffle_shop.__overview__",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "overview.md",
-            "original_file_path": "models/overview.md",
-            "name": "__overview__",
-            "block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
-        },
-        "jaffle_shop.orders_status": {
-            "unique_id": "jaffle_shop.orders_status",
-            "package_name": "jaffle_shop",
-            "root_path": "/private/tmp/jaffle_shop",
-            "path": "docs.md",
-            "original_file_path": "models/docs.md",
-            "name": "orders_status",
-            "block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
-        },
-        "dbt.__overview__": {
-            "unique_id": "dbt.__overview__",
-            "package_name": "dbt",
-            "root_path": "/Users/brito/.local/share/virtualenvs/jaffle_shop-o2nlWG-5/lib/python3.7/site-packages/dbt/include/global_project",
-            "path": "overview.md",
-            "original_file_path": "docs/overview.md",
-            "name": "__overview__",
-            "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
-        }
-    },
-    "exposures": {},
-    "selectors": {},
-    "disabled": [],
-    "parent_map": {
-        "model.jaffle_shop.customers": [
-            "model.jaffle_shop.stg_customers",
-            "model.jaffle_shop.stg_orders",
-            "model.jaffle_shop.stg_payments"
+      },
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": "jaffle_shop://models/schema.yml",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "materialized": "table"
+      },
+      "created_at": 1695745377.277432,
+      "relation_name": "sample_db.public.customers",
+      "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_customers"
         ],
-        "model.jaffle_shop.orders": [
-            "model.jaffle_shop.stg_orders",
-            "model.jaffle_shop.stg_payments"
+        [
+          "stg_orders"
         ],
-        "model.jaffle_shop.stg_customers": [
-            "seed.jaffle_shop.raw_customers"
-        ],
-        "model.jaffle_shop.stg_payments": [
-            "seed.jaffle_shop.raw_payments"
-        ],
-        "model.jaffle_shop.stg_orders": [
-            "seed.jaffle_shop.raw_orders"
-        ],
-        "seed.jaffle_shop.raw_customers": [],
-        "seed.jaffle_shop.raw_orders": [],
-        "seed.jaffle_shop.raw_payments": [],
-        "test.jaffle_shop.unique_customers_customer_id": [
-            "model.jaffle_shop.customers"
-        ],
-        "test.jaffle_shop.not_null_customers_customer_id": [
-            "model.jaffle_shop.customers"
-        ],
-        "test.jaffle_shop.unique_orders_order_id": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_order_id": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_customer_id": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_": [
-            "model.jaffle_shop.customers",
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_amount": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_credit_card_amount": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_coupon_amount": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_bank_transfer_amount": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.not_null_orders_gift_card_amount": [
-            "model.jaffle_shop.orders"
-        ],
-        "test.jaffle_shop.unique_stg_customers_customer_id": [
-            "model.jaffle_shop.stg_customers"
-        ],
-        "test.jaffle_shop.not_null_stg_customers_customer_id": [
-            "model.jaffle_shop.stg_customers"
-        ],
-        "test.jaffle_shop.unique_stg_orders_order_id": [
-            "model.jaffle_shop.stg_orders"
-        ],
-        "test.jaffle_shop.not_null_stg_orders_order_id": [
-            "model.jaffle_shop.stg_orders"
-        ],
-        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned": [
-            "model.jaffle_shop.stg_orders"
-        ],
-        "test.jaffle_shop.unique_stg_payments_payment_id": [
-            "model.jaffle_shop.stg_payments"
-        ],
-        "test.jaffle_shop.not_null_stg_payments_payment_id": [
-            "model.jaffle_shop.stg_payments"
-        ],
-        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card": [
-            "model.jaffle_shop.stg_payments"
+        [
+          "stg_payments"
         ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "model.jaffle_shop.stg_customers",
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/customers.sql",
+      "compiled": true,
+      "compiled_code": "with customers as (\n\n    select * from sample_db.public.stg_customers\n\n),\n\norders as (\n\n    select * from sample_db.public.stg_orders\n\n),\n\npayments as (\n\n    select * from sample_db.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+      "extra_ctes_injected": true,
+      "extra_ctes": []
     },
-    "child_map": {
-        "model.jaffle_shop.customers": [
-            "test.jaffle_shop.not_null_customers_customer_id",
-            "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_",
-            "test.jaffle_shop.unique_customers_customer_id"
+    "model.jaffle_shop.orders": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "orders",
+      "resource_type": "model",
+      "package_name": "jaffle_shop",
+      "path": "orders.sql",
+      "original_file_path": "models/orders.sql",
+      "unique_id": "model.jaffle_shop.orders",
+      "fqn": [
+        "jaffle_shop",
+        "orders"
+      ],
+      "alias": "orders",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "53950235d8e29690d259e95ee49bda6a5b7911b44c739b738a646dc6014bcfcd"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "table",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "This table has basic information about orders, as well as some derived facts based on payments",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "This is a unique identifier for an order",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Foreign key to the customers table",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "order_date": {
+          "name": "order_date",
+          "description": "Date (UTC) that the order was placed",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "status": {
+          "name": "status",
+          "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "amount": {
+          "name": "amount",
+          "description": "Total amount (AUD) of the order",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "credit_card_amount": {
+          "name": "credit_card_amount",
+          "description": "Amount of the order (AUD) paid for by credit card",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "coupon_amount": {
+          "name": "coupon_amount",
+          "description": "Amount of the order (AUD) paid for by coupon",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "bank_transfer_amount": {
+          "name": "bank_transfer_amount",
+          "description": "Amount of the order (AUD) paid for by bank transfer",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "gift_card_amount": {
+          "name": "gift_card_amount",
+          "description": "Amount of the order (AUD) paid for by gift card",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": "jaffle_shop://models/schema.yml",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "materialized": "table"
+      },
+      "created_at": 1695745377.283821,
+      "relation_name": "sample_db.public.orders",
+      "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_orders"
         ],
-        "model.jaffle_shop.orders": [
-            "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-            "test.jaffle_shop.not_null_orders_amount",
-            "test.jaffle_shop.not_null_orders_bank_transfer_amount",
-            "test.jaffle_shop.not_null_orders_coupon_amount",
-            "test.jaffle_shop.not_null_orders_credit_card_amount",
-            "test.jaffle_shop.not_null_orders_customer_id",
-            "test.jaffle_shop.not_null_orders_gift_card_amount",
-            "test.jaffle_shop.not_null_orders_order_id",
-            "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_",
-            "test.jaffle_shop.unique_orders_order_id"
+        [
+          "stg_payments"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/orders.sql",
+      "compiled": true,
+      "compiled_code": "\n\nwith orders as (\n\n    select * from sample_db.public.stg_orders\n\n),\n\npayments as (\n\n    select * from sample_db.public.stg_payments\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+      "extra_ctes_injected": true,
+      "extra_ctes": []
+    },
+    "model.jaffle_shop.stg_customers": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "stg_customers",
+      "resource_type": "model",
+      "package_name": "jaffle_shop",
+      "path": "staging/stg_customers.sql",
+      "original_file_path": "models/staging/stg_customers.sql",
+      "unique_id": "model.jaffle_shop.stg_customers",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "stg_customers"
+      ],
+      "alias": "stg_customers",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "6f18a29204dad1de6dbb0c288144c4990742e0a1e065c3b2a67b5f98334c22ba"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "view",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": "jaffle_shop://models/staging/schema.yml",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "materialized": "view"
+      },
+      "created_at": 1695745377.361583,
+      "relation_name": "sample_db.public.stg_customers",
+      "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+      "language": "sql",
+      "refs": [
+        [
+          "raw_customers"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "seed.jaffle_shop.raw_customers"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+      "compiled": true,
+      "compiled_code": "with source as (\n    select * from sample_db.public.raw_customers\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+      "extra_ctes_injected": true,
+      "extra_ctes": []
+    },
+    "model.jaffle_shop.stg_payments": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "stg_payments",
+      "resource_type": "model",
+      "package_name": "jaffle_shop",
+      "path": "staging/stg_payments.sql",
+      "original_file_path": "models/staging/stg_payments.sql",
+      "unique_id": "model.jaffle_shop.stg_payments",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "stg_payments"
+      ],
+      "alias": "stg_payments",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "eb899938258d1fba27fca716a7c334119912a2f9601282026097a7b6ce8cfcd2"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "view",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {
+        "payment_id": {
+          "name": "payment_id",
+          "description": "",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "description": "",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": "jaffle_shop://models/staging/schema.yml",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "materialized": "view"
+      },
+      "created_at": 1695745377.3644779,
+      "relation_name": "sample_db.public.stg_payments",
+      "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+      "language": "sql",
+      "refs": [
+        [
+          "raw_payments"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "seed.jaffle_shop.raw_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+      "compiled": true,
+      "compiled_code": "with source as (\n    select * from sample_db.public.raw_payments\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+      "extra_ctes_injected": true,
+      "extra_ctes": []
+    },
+    "model.jaffle_shop.stg_orders": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "stg_orders",
+      "resource_type": "model",
+      "package_name": "jaffle_shop",
+      "path": "staging/stg_orders.sql",
+      "original_file_path": "models/staging/stg_orders.sql",
+      "unique_id": "model.jaffle_shop.stg_orders",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "stg_orders"
+      ],
+      "alias": "stg_orders",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "afffa9cbc57e5fd2cf5898ebf571d444a62c9d6d7929d8133d30567fb9a2ce97"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "view",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "status": {
+          "name": "status",
+          "description": "",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": "jaffle_shop://models/staging/schema.yml",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "materialized": "view"
+      },
+      "created_at": 1695745377.363029,
+      "relation_name": "sample_db.public.stg_orders",
+      "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+      "language": "sql",
+      "refs": [
+        [
+          "raw_orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "seed.jaffle_shop.raw_orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+      "compiled": true,
+      "compiled_code": "with source as (\n    select * from sample_db.public.raw_orders\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+      "extra_ctes_injected": true,
+      "extra_ctes": []
+    },
+    "seed.jaffle_shop.raw_customers": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "raw_customers",
+      "resource_type": "seed",
+      "package_name": "jaffle_shop",
+      "path": "raw_customers.csv",
+      "original_file_path": "seeds/raw_customers.csv",
+      "unique_id": "seed.jaffle_shop.raw_customers",
+      "fqn": [
+        "jaffle_shop",
+        "raw_customers"
+      ],
+      "alias": "raw_customers",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "24579b4b26098d43265376f3c50be8b10faf8e8fd95f5508074f10f76a12671d"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "seed",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "quote_columns": null,
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.194678,
+      "relation_name": "sample_db.public.raw_customers",
+      "raw_code": "",
+      "root_path": "/private/tmp/jaffle_shop",
+      "depends_on": {
+        "macros": []
+      }
+    },
+    "seed.jaffle_shop.raw_orders": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "raw_orders",
+      "resource_type": "seed",
+      "package_name": "jaffle_shop",
+      "path": "raw_orders.csv",
+      "original_file_path": "seeds/raw_orders.csv",
+      "unique_id": "seed.jaffle_shop.raw_orders",
+      "fqn": [
+        "jaffle_shop",
+        "raw_orders"
+      ],
+      "alias": "raw_orders",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "ee6c68d1639ec2b23a4495ec12475e09b8ed4b61e23ab0411ea7ec76648356f7"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "seed",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "quote_columns": null,
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.198953,
+      "relation_name": "sample_db.public.raw_orders",
+      "raw_code": "",
+      "root_path": "/private/tmp/jaffle_shop",
+      "depends_on": {
+        "macros": []
+      }
+    },
+    "seed.jaffle_shop.raw_payments": {
+      "database": "sample_db",
+      "schema": "public",
+      "name": "raw_payments",
+      "resource_type": "seed",
+      "package_name": "jaffle_shop",
+      "path": "raw_payments.csv",
+      "original_file_path": "seeds/raw_payments.csv",
+      "unique_id": "seed.jaffle_shop.raw_payments",
+      "fqn": [
+        "jaffle_shop",
+        "raw_payments"
+      ],
+      "alias": "raw_payments",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "03fd407f3135f84456431a923f22fc185a2154079e210c20b690e3ab11687d11"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "seed",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "quote_columns": null,
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.202805,
+      "relation_name": "sample_db.public.raw_payments",
+      "raw_code": "",
+      "root_path": "/private/tmp/jaffle_shop",
+      "depends_on": {
+        "macros": []
+      }
+    },
+    "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": {
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('customers')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "unique_customers_customer_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "unique_customers_customer_id.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+      "fqn": [
+        "jaffle_shop",
+        "unique_customers_customer_id"
+      ],
+      "alias": "unique_customers_customer_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.30729,
+      "relation_name": null,
+      "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "customers"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
         ],
-        "model.jaffle_shop.stg_customers": [
-            "model.jaffle_shop.customers",
-            "test.jaffle_shop.not_null_stg_customers_customer_id",
-            "test.jaffle_shop.unique_stg_customers_customer_id"
+        "nodes": [
+          "model.jaffle_shop.customers"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_customers_customer_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom sample_db.public.customers\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.customers"
+    },
+    "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('customers')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_customers_customer_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_customers_customer_id.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_customers_customer_id"
+      ],
+      "alias": "not_null_customers_customer_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.310553,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "customers"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
-        "model.jaffle_shop.stg_payments": [
-            "model.jaffle_shop.customers",
-            "model.jaffle_shop.orders",
-            "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-            "test.jaffle_shop.not_null_stg_payments_payment_id",
-            "test.jaffle_shop.unique_stg_payments_payment_id"
+        "nodes": [
+          "model.jaffle_shop.customers"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_customers_customer_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom sample_db.public.customers\nwhere customer_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.customers"
+    },
+    "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "order_id",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "unique_orders_order_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "unique_orders_order_id.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "fqn": [
+        "jaffle_shop",
+        "unique_orders_order_id"
+      ],
+      "alias": "unique_orders_order_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.31383,
+      "relation_name": null,
+      "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
         ],
-        "model.jaffle_shop.stg_orders": [
-            "model.jaffle_shop.customers",
-            "model.jaffle_shop.orders",
-            "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-            "test.jaffle_shop.not_null_stg_orders_order_id",
-            "test.jaffle_shop.unique_stg_orders_order_id"
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_orders_order_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom sample_db.public.orders\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "order_id",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "order_id",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_order_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_order_id.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_order_id"
+      ],
+      "alias": "not_null_orders_order_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3170838,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
-        "seed.jaffle_shop.raw_customers": [
-            "model.jaffle_shop.stg_customers"
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_order_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom sample_db.public.orders\nwhere order_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "order_id",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_customer_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_customer_id.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_customer_id"
+      ],
+      "alias": "not_null_orders_customer_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3201642,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
-        "seed.jaffle_shop.raw_orders": [
-            "model.jaffle_shop.stg_orders"
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_customer_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom sample_db.public.orders\nwhere customer_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": {
+      "test_metadata": {
+        "name": "relationships",
+        "kwargs": {
+          "to": "ref('customers')",
+          "field": "customer_id",
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "relationships_orders_customer_id__customer_id__ref_customers_",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "relationships_orders_customer_id__customer_id__ref_customers_.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+      "fqn": [
+        "jaffle_shop",
+        "relationships_orders_customer_id__customer_id__ref_customers_"
+      ],
+      "alias": "relationships_orders_customer_id__customer_id__ref_customers_",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.323173,
+      "relation_name": null,
+      "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "customers"
         ],
-        "seed.jaffle_shop.raw_payments": [
-            "model.jaffle_shop.stg_payments"
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_relationships",
+          "macro.dbt.get_where_subquery"
         ],
-        "test.jaffle_shop.unique_customers_customer_id": [],
-        "test.jaffle_shop.not_null_customers_customer_id": [],
-        "test.jaffle_shop.unique_orders_order_id": [],
-        "test.jaffle_shop.not_null_orders_order_id": [],
-        "test.jaffle_shop.not_null_orders_customer_id": [],
-        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_": [],
-        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned": [],
-        "test.jaffle_shop.not_null_orders_amount": [],
-        "test.jaffle_shop.not_null_orders_credit_card_amount": [],
-        "test.jaffle_shop.not_null_orders_coupon_amount": [],
-        "test.jaffle_shop.not_null_orders_bank_transfer_amount": [],
-        "test.jaffle_shop.not_null_orders_gift_card_amount": [],
-        "test.jaffle_shop.unique_stg_customers_customer_id": [],
-        "test.jaffle_shop.not_null_stg_customers_customer_id": [],
-        "test.jaffle_shop.unique_stg_orders_order_id": [],
-        "test.jaffle_shop.not_null_stg_orders_order_id": [],
-        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned": [],
-        "test.jaffle_shop.unique_stg_payments_payment_id": [],
-        "test.jaffle_shop.not_null_stg_payments_payment_id": [],
-        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card": []
+        "nodes": [
+          "model.jaffle_shop.customers",
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/relationships_orders_customer_id__customer_id__ref_customers_.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith child as (\n    select customer_id as from_field\n    from sample_db.public.orders\n    where customer_id is not null\n),\n\nparent as (\n    select customer_id as to_field\n    from sample_db.public.customers\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+      "test_metadata": {
+        "name": "accepted_values",
+        "kwargs": {
+          "values": [
+            "placed",
+            "shipped",
+            "completed",
+            "return_pending",
+            "returned"
+          ],
+          "column_name": "status",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "fqn": [
+        "jaffle_shop",
+        "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
+      ],
+      "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
+      },
+      "created_at": 1695745377.336614,
+      "relation_name": null,
+      "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_accepted_values",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from sample_db.public.orders\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "status",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_amount.106140f9fd": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "amount",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_amount",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_amount.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_amount"
+      ],
+      "alias": "not_null_orders_amount",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.347949,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_amount.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect amount\nfrom sample_db.public.orders\nwhere amount is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "amount",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "credit_card_amount",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_credit_card_amount",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_credit_card_amount.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_credit_card_amount"
+      ],
+      "alias": "not_null_orders_credit_card_amount",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.350506,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_credit_card_amount.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect credit_card_amount\nfrom sample_db.public.orders\nwhere credit_card_amount is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "credit_card_amount",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "coupon_amount",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_coupon_amount",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_coupon_amount.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_coupon_amount"
+      ],
+      "alias": "not_null_orders_coupon_amount",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3539479,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_coupon_amount.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect coupon_amount\nfrom sample_db.public.orders\nwhere coupon_amount is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "coupon_amount",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "bank_transfer_amount",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_bank_transfer_amount",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_bank_transfer_amount.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_bank_transfer_amount"
+      ],
+      "alias": "not_null_orders_bank_transfer_amount",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.356454,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_bank_transfer_amount.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect bank_transfer_amount\nfrom sample_db.public.orders\nwhere bank_transfer_amount is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "bank_transfer_amount",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "gift_card_amount",
+          "model": "{{ get_where_subquery(ref('orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_orders_gift_card_amount",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_orders_gift_card_amount.sql",
+      "original_file_path": "models/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "fqn": [
+        "jaffle_shop",
+        "not_null_orders_gift_card_amount"
+      ],
+      "alias": "not_null_orders_gift_card_amount",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3589592,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_orders_gift_card_amount.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect gift_card_amount\nfrom sample_db.public.orders\nwhere gift_card_amount is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "gift_card_amount",
+      "file_key_name": "models.orders"
+    },
+    "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": {
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "unique_stg_customers_customer_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "unique_stg_customers_customer_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "unique_stg_customers_customer_id"
+      ],
+      "alias": "unique_stg_customers_customer_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.365488,
+      "relation_name": null,
+      "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_customers"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_customers"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_customers_customer_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom sample_db.public.stg_customers\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.stg_customers"
+    },
+    "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "customer_id",
+          "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_stg_customers_customer_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_stg_customers_customer_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "not_null_stg_customers_customer_id"
+      ],
+      "alias": "not_null_stg_customers_customer_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3682098,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_customers"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_customers"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_customers_customer_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom sample_db.public.stg_customers\nwhere customer_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "customer_id",
+      "file_key_name": "models.stg_customers"
+    },
+    "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": {
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "order_id",
+          "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "unique_stg_orders_order_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "unique_stg_orders_order_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "unique_stg_orders_order_id"
+      ],
+      "alias": "unique_stg_orders_order_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.370733,
+      "relation_name": null,
+      "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_orders_order_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom sample_db.public.stg_orders\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "order_id",
+      "file_key_name": "models.stg_orders"
+    },
+    "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "order_id",
+          "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_stg_orders_order_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_stg_orders_order_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "not_null_stg_orders_order_id"
+      ],
+      "alias": "not_null_stg_orders_order_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.3732438,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_orders_order_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom sample_db.public.stg_orders\nwhere order_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "order_id",
+      "file_key_name": "models.stg_orders"
+    },
+    "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
+      "test_metadata": {
+        "name": "accepted_values",
+        "kwargs": {
+          "values": [
+            "placed",
+            "shipped",
+            "completed",
+            "return_pending",
+            "returned"
+          ],
+          "column_name": "status",
+          "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
+      ],
+      "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+      },
+      "created_at": 1695745377.375794,
+      "relation_name": null,
+      "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_orders"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_accepted_values",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_orders"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from sample_db.public.stg_orders\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "status",
+      "file_key_name": "models.stg_orders"
+    },
+    "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": {
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "payment_id",
+          "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "unique_stg_payments_payment_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "unique_stg_payments_payment_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "unique_stg_payments_payment_id"
+      ],
+      "alias": "unique_stg_payments_payment_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.383015,
+      "relation_name": null,
+      "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_payments"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_payments_payment_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    payment_id as unique_field,\n    count(*) as n_records\n\nfrom sample_db.public.stg_payments\nwhere payment_id is not null\ngroup by payment_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "payment_id",
+      "file_key_name": "models.stg_payments"
+    },
+    "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": {
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "payment_id",
+          "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "not_null_stg_payments_payment_id",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "not_null_stg_payments_payment_id.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "not_null_stg_payments_payment_id"
+      ],
+      "alias": "not_null_stg_payments_payment_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1695745377.38553,
+      "relation_name": null,
+      "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_payments"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_payments_payment_id.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect payment_id\nfrom sample_db.public.stg_payments\nwhere payment_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "payment_id",
+      "file_key_name": "models.stg_payments"
+    },
+    "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+      "test_metadata": {
+        "name": "accepted_values",
+        "kwargs": {
+          "values": [
+            "credit_card",
+            "coupon",
+            "bank_transfer",
+            "gift_card"
+          ],
+          "column_name": "payment_method",
+          "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+        },
+        "namespace": null
+      },
+      "database": "sample_db",
+      "schema": "public_dbt_test__audit",
+      "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+      "resource_type": "test",
+      "package_name": "jaffle_shop",
+      "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+      "original_file_path": "models/staging/schema.yml",
+      "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "fqn": [
+        "jaffle_shop",
+        "staging",
+        "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+      ],
+      "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "config": {
+        "enabled": true,
+        "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+      },
+      "created_at": 1695745377.3882828,
+      "relation_name": null,
+      "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+      "language": "sql",
+      "refs": [
+        [
+          "stg_payments"
+        ]
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_accepted_values",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.jaffle_shop.stg_payments"
+        ]
+      },
+      "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        payment_method as value_field,\n        count(*) as n_records\n\n    from sample_db.public.stg_payments\n    group by payment_method\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'credit_card','coupon','bank_transfer','gift_card'\n)\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "column_name": "payment_method",
+      "file_key_name": "models.stg_payments"
     }
+  },
+  "sources": {},
+  "docs": {
+    "doc.jaffle_shop.__overview__": {
+      "name": "__overview__",
+      "resource_type": "doc",
+      "package_name": "jaffle_shop",
+      "path": "overview.md",
+      "original_file_path": "models/overview.md",
+      "unique_id": "doc.jaffle_shop.__overview__",
+      "block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+    },
+    "doc.jaffle_shop.orders_status": {
+      "name": "orders_status",
+      "resource_type": "doc",
+      "package_name": "jaffle_shop",
+      "path": "docs.md",
+      "original_file_path": "models/docs.md",
+      "unique_id": "doc.jaffle_shop.orders_status",
+      "block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+    },
+    "doc.dbt.__overview__": {
+      "name": "__overview__",
+      "resource_type": "doc",
+      "package_name": "dbt",
+      "path": "overview.md",
+      "original_file_path": "docs/overview.md",
+      "unique_id": "doc.dbt.__overview__",
+      "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+    }
+  },
+  "exposures": {},
+  "metrics": {},
+  "selectors": {},
+  "disabled": {},
+  "parent_map": {
+    "model.jaffle_shop.customers": [
+      "model.jaffle_shop.stg_customers",
+      "model.jaffle_shop.stg_orders",
+      "model.jaffle_shop.stg_payments"
+    ],
+    "model.jaffle_shop.orders": [
+      "model.jaffle_shop.stg_orders",
+      "model.jaffle_shop.stg_payments"
+    ],
+    "model.jaffle_shop.stg_customers": [
+      "seed.jaffle_shop.raw_customers"
+    ],
+    "model.jaffle_shop.stg_payments": [
+      "seed.jaffle_shop.raw_payments"
+    ],
+    "model.jaffle_shop.stg_orders": [
+      "seed.jaffle_shop.raw_orders"
+    ],
+    "seed.jaffle_shop.raw_customers": [],
+    "seed.jaffle_shop.raw_orders": [],
+    "seed.jaffle_shop.raw_payments": [],
+    "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": [
+      "model.jaffle_shop.customers"
+    ],
+    "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": [
+      "model.jaffle_shop.customers"
+    ],
+    "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [
+      "model.jaffle_shop.customers",
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_amount.106140f9fd": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [
+      "model.jaffle_shop.orders"
+    ],
+    "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [
+      "model.jaffle_shop.stg_customers"
+    ],
+    "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+      "model.jaffle_shop.stg_customers"
+    ],
+    "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [
+      "model.jaffle_shop.stg_orders"
+    ],
+    "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [
+      "model.jaffle_shop.stg_orders"
+    ],
+    "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
+      "model.jaffle_shop.stg_orders"
+    ],
+    "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [
+      "model.jaffle_shop.stg_payments"
+    ],
+    "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [
+      "model.jaffle_shop.stg_payments"
+    ],
+    "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
+      "model.jaffle_shop.stg_payments"
+    ]
+  },
+  "child_map": {
+    "model.jaffle_shop.customers": [
+      "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+      "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+      "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1"
+    ],
+    "model.jaffle_shop.orders": [
+      "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+      "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+    ],
+    "model.jaffle_shop.stg_customers": [
+      "model.jaffle_shop.customers",
+      "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+    ],
+    "model.jaffle_shop.stg_payments": [
+      "model.jaffle_shop.customers",
+      "model.jaffle_shop.orders",
+      "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+    ],
+    "model.jaffle_shop.stg_orders": [
+      "model.jaffle_shop.customers",
+      "model.jaffle_shop.orders",
+      "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+    ],
+    "seed.jaffle_shop.raw_customers": [
+      "model.jaffle_shop.stg_customers"
+    ],
+    "seed.jaffle_shop.raw_orders": [
+      "model.jaffle_shop.stg_orders"
+    ],
+    "seed.jaffle_shop.raw_payments": [
+      "model.jaffle_shop.stg_payments"
+    ],
+    "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": [],
+    "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": [],
+    "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [],
+    "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [],
+    "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [],
+    "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [],
+    "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [],
+    "test.jaffle_shop.not_null_orders_amount.106140f9fd": [],
+    "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [],
+    "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [],
+    "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [],
+    "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [],
+    "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
+    "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+    "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
+    "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
+    "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+    "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [],
+    "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [],
+    "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": []
+  }
 }

--- a/tests/_integration/test_tableau_crawler.py
+++ b/tests/_integration/test_tableau_crawler.py
@@ -180,10 +180,10 @@ def mock_tableau_rest_api():
 )
 def test_tableau_crawler(manifest_path):
     with patch.object(DbtManifest, 'save', autospec=True) as mock:
-        tableau_crawler(manifest_path, 'jeffle_shop', [], True)
+        tableau_crawler(manifest_path, 'jaffle_shop', [], True)
 
         final_manifest = mock.call_args.args[0].data
-        exposure = final_manifest['exposures']['exposure.jeffle_shop.tableau_orders_workbook_ccc']
+        exposure = final_manifest['exposures']['exposure.jaffle_shop.tableau_orders_workbook_ccc']
 
         assert len(final_manifest['exposures']) == 3
         assert exposure['name'] == 'tableau_orders_workbook_ccc'


### PR DESCRIPTION
The fixtures needed for the test suite were generated on dbt 0.19, which is very old by now. We are bumping it to dbt 1.4, which is what we currently use in production at Voi.