### PR TITLE
Authenticate tableau with personal access token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 TABLEAU_URL=https://mytableauserver.company.com # without a trailling slash
 TABLEAU_USERNAME=some_username
 TABLEAU_PASSWORD=some_password
+TABLEAU_TOKEN_NAME=your_pat_name
+TABLEAU_TOKEN_VALUE=tokens_private_value

--- a/src/exposurescrawler/crawlers/tableau.py
+++ b/src/exposurescrawler/crawlers/tableau.py
@@ -23,7 +23,7 @@ def _should_ignore_workbook(workbook, projects_to_ignore: Collection[str]) -> bo
     # by workbooks under projects without a name.
     if not workbook.project_name:
         return True
-    
+
     return workbook.project_name in projects_to_ignore
 
 
@@ -87,11 +87,18 @@ def tableau_crawler(
     models = manifest.retrieve_models_and_sources()
 
     # Configure the Tableau REST client
-    tableau_client = TableauRestClient(
-        os.environ['TABLEAU_URL'],
-        os.environ['TABLEAU_USERNAME'],
-        os.environ['TABLEAU_PASSWORD'],
-    )
+    if 'TABLEAU_USERNAME' in os.environ and 'TABLEAU_PASSWORD' in os.environ:
+        tableau_client = TableauRestClient.config_user_and_password(
+            os.environ['TABLEAU_URL'],
+            os.environ['TABLEAU_USERNAME'],
+            os.environ['TABLEAU_PASSWORD'],
+        )
+    else:
+        tableau_client = TableauRestClient.config_token(
+            os.environ['TABLEAU_URL'],
+            os.environ['TABLEAU_TOKEN_NAME'],
+            os.environ['TABLEAU_TOKEN_VALUE'],
+        )
 
     # Retrieve custom SQLs and find model references
     workbooks_custom_sqls = retrieve_custom_sql(tableau_client, 'snowflake')

--- a/src/exposurescrawler/tableau/rest_client.py
+++ b/src/exposurescrawler/tableau/rest_client.py
@@ -5,11 +5,28 @@ from functools import lru_cache
 class TableauRestClient:
     """
     Thin wrapper around the official Tableau Server client.
+    Initialized with user+passw or access token
     """
 
-    def __init__(self, url: str, username: str, password: str):
-        self.tableau_auth = TSC.TableauAuth(username, password)
+    def __init__(self, url: str):
+        self.url = url
         self.server = TSC.Server(url, use_server_version=True)
+
+    @classmethod
+    def config_user_and_password(cls, url: str, username: str, password: str):
+        # Specific initialization to tableau server via user and password
+        tableau_cls = cls(url=url)
+        tableau_cls.tableau_auth = TSC.TableauAuth(username, password)
+
+        return tableau_cls
+
+    @classmethod
+    def config_token(cls, url: str, token_name: str, token_value: str):
+        # Specific initialization to tableau server via access token
+        tableau_cls = cls(url=url)
+        tableau_cls.tableau_auth = TSC.PersonalAccessTokenAuth(token_name, token_value)
+
+        return tableau_cls
 
     @lru_cache(maxsize=None)
     def retrieve_workbook(self, workbook_id: str):


### PR DESCRIPTION
Added option to authenticate tableau using a person access token since some accounts do not allow user+password.

Tested locally on manifest which ran successfully
<img width="971" alt="Screenshot 2023-12-14 at 08 52 44" src="https://github.com/voi-oss/dbt-exposures-crawler/assets/130447951/a65da1e3-892e-4441-85b9-c66be3992f8b">

Let me know if I missed something